### PR TITLE
Update tests to provision 3 nodes cluster tests with a replicated loglet with replication property 2

### DIFF
--- a/src/main/kotlin/dev/restate/sdktesting/infra/RestateContainer.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/infra/RestateContainer.kt
@@ -63,7 +63,7 @@ class RestateContainer(
                             .build()))
             .withStartupTimeout(120.seconds.toJavaDuration())
 
-    fun bootstrapRestateCluster(
+    fun createRestateContainers(
         config: RestateDeployerConfig,
         network: Network,
         envs: Map<String, String>,
@@ -79,14 +79,17 @@ class RestateContainer(
         val leaderEnvs =
             mapOf<String, String>(
                 "RESTATE_CLUSTER_NAME" to clusterId,
-                "RESTATE_BIFROST__DEFAULT_PROVIDER" to "replicated",
                 "RESTATE_ALLOW_BOOTSTRAP" to "true",
+                "RESTATE_BIFROST__DEFAULT_PROVIDER" to "replicated",
+                "RESTATE_BIFROST__REPLICATED_LOGLET__DEFAULT_REPLICATION_PROPERTY" to "2",
                 "RESTATE_ROLES" to "[worker,log-server,admin,metadata-store]",
             )
         val followerEnvs =
             mapOf<String, String>(
                 "RESTATE_CLUSTER_NAME" to clusterId,
+                "RESTATE_ALLOW_BOOTSTRAP" to "false",
                 "RESTATE_BIFROST__DEFAULT_PROVIDER" to "replicated",
+                "RESTATE_BIFROST__REPLICATED_LOGLET__DEFAULT_REPLICATION_PROPERTY" to "2",
                 "RESTATE_ROLES" to "[worker,admin,log-server]",
                 "RESTATE_METADATA_STORE_CLIENT__ADDRESS" to
                     "http://$RESTATE_RUNTIME:$RUNTIME_NODE_PORT")

--- a/src/main/kotlin/dev/restate/sdktesting/infra/RestateDeployer.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/infra/RestateDeployer.kt
@@ -169,7 +169,7 @@ private constructor(
           }
           .associate { it.second.first to (it.first to it.second.second) }
   private val runtimeContainers: List<RestateContainer> =
-      RestateContainer.bootstrapRestateCluster(
+      RestateContainer.createRestateContainers(
           config, network, runtimeContainerEnvs, configSchema, copyToContainer, config.restateNodes)
 
   private val deployedContainers: Map<String, ContainerHandle> =


### PR DESCRIPTION
This commit adds the NodeCtl grpc svc to the repo to generate a grpc client to manually provision a replicated loglet with a replciation property 2. W/o manually provisioning the cluster, the replication property defaults to 1.

Note: Whenever the *.proto files change in the restate repo, they need to be updated in this repository as well if there is an incompatible change.

This fixes #26.