### PR TITLE
Set DO_NOT_TRACK on all deployed restate containers

### DIFF
--- a/src/main/kotlin/dev/restate/sdktesting/infra/RestateContainer.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/infra/RestateContainer.kt
@@ -134,6 +134,7 @@ class RestateContainer(
       // These envs should not be overriden by envs
       withEnv("RESTATE_ADMIN__BIND_ADDRESS", "0.0.0.0:$RUNTIME_ADMIN_ENDPOINT_PORT")
       withEnv("RESTATE_INGRESS__BIND_ADDRESS", "0.0.0.0:$RUNTIME_INGRESS_ENDPOINT_PORT")
+      withEnv("DO_NOT_TRACK", "true")
 
       this.network = network
       this.networkAliases = arrayListOf(hostname)


### PR DESCRIPTION
This will (soon) be one of the ways to disable telemetry and we want to avoid polluting the telemetry data with our integration tests