### PR TITLE
Assorted improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
   implementation(libs.log4j.api)
   implementation(libs.log4j.core)
   implementation(libs.log4j.slf4j)
+  implementation(libs.log4j.kotlin)
 
   implementation("org.apache.kafka:kafka-clients:3.5.0")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ dependencyResolutionManagement {
       library("log4j-api", "org.apache.logging.log4j", "log4j-api").versionRef("log4j")
       library("log4j-core", "org.apache.logging.log4j", "log4j-core").versionRef("log4j")
       library("log4j-slf4j", "org.apache.logging.log4j", "log4j-slf4j-impl").versionRef("log4j")
+      library("log4j-kotlin", "org.apache.logging.log4j", "log4j-api-kotlin").version("1.5.0")
 
       version("jackson", "2.16.1")
       library("jackson-core", "com.fasterxml.jackson.core", "jackson-core").versionRef("jackson")

--- a/src/main/kotlin/dev/restate/sdktesting/infra/ContainerHandle.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/infra/ContainerHandle.kt
@@ -22,8 +22,7 @@ import org.testcontainers.utility.LogUtils
 class ContainerHandle
 internal constructor(
     internal val container: GenericContainer<*>,
-    private val getMappedPort: (Int) -> Int? = { container.getMappedPort(it) },
-    private val restartWaitStrategy: () -> Unit = {},
+    private val afterRestartWaitStrategy: () -> Unit = {},
 ) {
 
   private val logger = LogManager.getLogger(ContainerHandle::class.java)
@@ -99,7 +98,7 @@ internal constructor(
   }
 
   fun getMappedPort(port: Int): Int? {
-    return this.getMappedPort.invoke(port)
+    return container.getMappedPort(port)
   }
 
   private fun postStart() {
@@ -115,7 +114,7 @@ internal constructor(
     }
 
     // Additional wait strategy for ports
-    restartWaitStrategy()
+    afterRestartWaitStrategy()
 
     logger.info("Container {} started and passed all the checks.", container.containerName)
   }

--- a/src/main/kotlin/dev/restate/sdktesting/infra/RestateContainer.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/infra/RestateContainer.kt
@@ -192,7 +192,6 @@ class RestateContainer(
 
   override fun getContainerInfo(): InspectContainerResponse {
     // We override container info to avoid getting outdated info when restarted
-    val containerId = this.containerId
-    return dockerClient.inspectContainerCmd(containerId).exec()
+    return currentContainerInfo
   }
 }

--- a/src/main/kotlin/dev/restate/sdktesting/infra/RestateDeployer.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/infra/RestateDeployer.kt
@@ -175,7 +175,7 @@ private constructor(
 
   private val deployedContainers: Map<String, ContainerHandle> =
       (runtimeContainers.map {
-            it.hostname to ContainerHandle(it, restartWaitStrategy = { it.waitStartup() })
+            it.hostname to ContainerHandle(it, afterRestartWaitStrategy = { it.waitStartup() })
           } +
               serviceContainers.map { it.key to ContainerHandle(it.value.second) } +
               additionalContainers.map { it.key to ContainerHandle(it.value) })

--- a/src/main/kotlin/dev/restate/sdktesting/tests/AwaitTimeout.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/AwaitTimeout.kt
@@ -13,7 +13,6 @@ import dev.restate.sdktesting.contracts.*
 import dev.restate.sdktesting.infra.*
 import java.time.Duration
 import java.util.UUID
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Tag

--- a/src/main/kotlin/dev/restate/sdktesting/tests/CallOrdering.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/CallOrdering.kt
@@ -15,7 +15,6 @@ import dev.restate.sdktesting.infra.RestateDeployerExtension
 import dev.restate.sdktesting.infra.ServiceSpec
 import java.util.UUID
 import java.util.stream.Stream
-import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat

--- a/src/main/kotlin/dev/restate/sdktesting/tests/CancelInvocation.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/CancelInvocation.kt
@@ -18,7 +18,6 @@ import java.net.URL
 import java.util.*
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.*
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.withAlias

--- a/src/main/kotlin/dev/restate/sdktesting/tests/Ingress.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/Ingress.kt
@@ -20,7 +20,6 @@ import dev.restate.sdktesting.infra.*
 import java.net.URL
 import java.util.*
 import java.util.concurrent.TimeUnit
-import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat

--- a/src/main/kotlin/dev/restate/sdktesting/tests/KafkaIngress.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/KafkaIngress.kt
@@ -22,7 +22,6 @@ import dev.restate.sdktesting.infra.runtimeconfig.KafkaClusterOptions
 import dev.restate.sdktesting.infra.runtimeconfig.RestateConfigSchema
 import java.net.URL
 import java.util.*
-import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.apache.kafka.clients.producer.KafkaProducer

--- a/src/main/kotlin/dev/restate/sdktesting/tests/KillInvocation.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/KillInvocation.kt
@@ -15,7 +15,6 @@ import dev.restate.sdk.client.Client
 import dev.restate.sdktesting.contracts.*
 import dev.restate.sdktesting.infra.*
 import java.net.URL
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.withAlias

--- a/src/main/kotlin/dev/restate/sdktesting/tests/KillRuntime.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/KillRuntime.kt
@@ -18,8 +18,9 @@ import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.withAlias
 import org.junit.jupiter.api.Tag
@@ -59,8 +60,9 @@ class KillRuntime {
     // Stop and start the runtime
     runtimeHandle.killAndRestart()
 
-    await.timeout(Duration.of(60, ChronoUnit.SECONDS)) withAlias
-        "second add" untilAsserted
+    await withAlias
+        "second add" atMost
+        Duration.of(60, ChronoUnit.SECONDS) untilAsserted
         {
           // We need a new client, because on restarts docker might mess up the exposed ports.
           // NotFunky
@@ -71,7 +73,9 @@ class KillRuntime {
               DefaultClient.of(
                   httpClient, "http://127.0.0.1:${runtimeHandle.getMappedPort(8080)!!}", HashMap())
           val res2 =
-              CounterClient.fromClient(ingressClient, "my-key").add(2, idempotentCallOptions())
+              withTimeout(5.seconds) {
+                CounterClient.fromClient(ingressClient, "my-key").add(2, idempotentCallOptions())
+              }
           assertThat(res2.oldValue).isEqualTo(1)
           assertThat(res2.newValue).isEqualTo(3)
         }

--- a/src/main/kotlin/dev/restate/sdktesting/tests/NonDeterminismErrors.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/NonDeterminismErrors.kt
@@ -15,7 +15,6 @@ import dev.restate.sdktesting.contracts.CounterClient
 import dev.restate.sdktesting.contracts.CounterDefinitions
 import dev.restate.sdktesting.contracts.NonDeterministicDefinitions
 import dev.restate.sdktesting.infra.*
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.*
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.withAlias

--- a/src/main/kotlin/dev/restate/sdktesting/tests/PrivateService.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/PrivateService.kt
@@ -19,7 +19,6 @@ import java.net.URL
 import java.util.*
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat

--- a/src/main/kotlin/dev/restate/sdktesting/tests/ProxyRequestSigning.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/ProxyRequestSigning.kt
@@ -15,7 +15,6 @@ import dev.restate.sdktesting.infra.InjectClient
 import dev.restate.sdktesting.infra.RestateDeployerExtension
 import dev.restate.sdktesting.infra.ServiceSpec
 import java.util.*
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension

--- a/src/main/kotlin/dev/restate/sdktesting/tests/RawHandler.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/RawHandler.kt
@@ -15,7 +15,6 @@ import dev.restate.sdktesting.infra.InjectClient
 import dev.restate.sdktesting.infra.RestateDeployerExtension
 import dev.restate.sdktesting.infra.ServiceSpec
 import kotlin.random.Random
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test

--- a/src/main/kotlin/dev/restate/sdktesting/tests/RunFlush.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/RunFlush.kt
@@ -15,7 +15,6 @@ import dev.restate.sdktesting.infra.InjectClient
 import dev.restate.sdktesting.infra.RestateDeployerExtension
 import dev.restate.sdktesting.infra.ServiceSpec
 import java.util.*
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Tag

--- a/src/main/kotlin/dev/restate/sdktesting/tests/RunRetry.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/RunRetry.kt
@@ -15,7 +15,6 @@ import dev.restate.sdktesting.infra.InjectClient
 import dev.restate.sdktesting.infra.RestateDeployerExtension
 import dev.restate.sdktesting.infra.ServiceSpec
 import java.util.*
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Tag

--- a/src/main/kotlin/dev/restate/sdktesting/tests/ServiceToServiceCommunication.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/ServiceToServiceCommunication.kt
@@ -15,7 +15,6 @@ import dev.restate.sdktesting.infra.RestateDeployerExtension
 import dev.restate.sdktesting.infra.ServiceSpec
 import java.util.UUID
 import java.util.concurrent.TimeUnit
-import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat

--- a/src/main/kotlin/dev/restate/sdktesting/tests/Sleep.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/Sleep.kt
@@ -23,7 +23,6 @@ import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test

--- a/src/main/kotlin/dev/restate/sdktesting/tests/SleepWithFailures.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/SleepWithFailures.kt
@@ -21,7 +21,6 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 import kotlin.time.toJavaDuration
 import kotlinx.coroutines.*
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test

--- a/src/main/kotlin/dev/restate/sdktesting/tests/State.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/State.kt
@@ -15,7 +15,6 @@ import dev.restate.sdktesting.infra.RestateDeployerExtension
 import dev.restate.sdktesting.infra.ServiceSpec
 import java.util.*
 import java.util.function.Function
-import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat

--- a/src/main/kotlin/dev/restate/sdktesting/tests/StopRuntime.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/StopRuntime.kt
@@ -18,8 +18,9 @@ import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.withAlias
 import org.junit.jupiter.api.Tag
@@ -59,8 +60,9 @@ class StopRuntime {
     // Stop and start the runtime
     runtimeHandle.terminateAndRestart()
 
-    await.timeout(Duration.of(60, ChronoUnit.SECONDS)) withAlias
-        "second add" untilAsserted
+    await withAlias
+        "second add" atMost
+        Duration.of(60, ChronoUnit.SECONDS) untilAsserted
         {
           // We need a new client, because on restarts docker might mess up the exposed ports.
           // NotFunky but true...
@@ -70,7 +72,9 @@ class StopRuntime {
               DefaultClient.of(
                   httpClient, "http://127.0.0.1:${runtimeHandle.getMappedPort(8080)!!}", HashMap())
           val res2 =
-              CounterClient.fromClient(ingressClient, "my-key").add(2, idempotentCallOptions())
+              withTimeout(5.seconds) {
+                CounterClient.fromClient(ingressClient, "my-key").add(2, idempotentCallOptions())
+              }
           assertThat(res2.oldValue).isEqualTo(1)
           assertThat(res2.newValue).isEqualTo(3)
         }

--- a/src/main/kotlin/dev/restate/sdktesting/tests/UpgradeWithInFlightInvocation.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/UpgradeWithInFlightInvocation.kt
@@ -16,7 +16,6 @@ import dev.restate.sdk.client.Client
 import dev.restate.sdktesting.contracts.*
 import dev.restate.sdktesting.infra.*
 import java.net.URL
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.withAlias

--- a/src/main/kotlin/dev/restate/sdktesting/tests/UpgradeWithNewInvocation.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/UpgradeWithNewInvocation.kt
@@ -16,7 +16,6 @@ import dev.restate.sdk.client.Client
 import dev.restate.sdktesting.contracts.*
 import dev.restate.sdktesting.infra.*
 import java.net.URL
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.withAlias

--- a/src/main/kotlin/dev/restate/sdktesting/tests/UserErrors.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/UserErrors.kt
@@ -15,7 +15,6 @@ import dev.restate.sdktesting.contracts.FailingClient
 import dev.restate.sdktesting.contracts.FailingDefinitions
 import dev.restate.sdktesting.infra.*
 import java.util.*
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Tag

--- a/src/main/kotlin/dev/restate/sdktesting/tests/WorkflowAPI.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/WorkflowAPI.kt
@@ -14,7 +14,6 @@ import dev.restate.sdktesting.contracts.BlockAndWaitWorkflowClient
 import dev.restate.sdktesting.contracts.BlockAndWaitWorkflowDefinitions
 import dev.restate.sdktesting.infra.*
 import java.util.*
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.withAlias


### PR DESCRIPTION
* Thread context propagation used by loggers now works correctly when in coroutine context
* Add a shorter timeout to the requests sent in KillRuntime/StopRuntime