### PR TITLE
Let untilAsserted retry on TimeoutCancellationException

### DIFF
--- a/src/main/kotlin/dev/restate/sdktesting/tests/utils.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/utils.kt
@@ -33,7 +33,7 @@ private val LOG = LogManager.getLogger("dev.restate.sdktesting.tests")
 suspend infix fun ConditionFactory.untilAsserted(fn: suspend () -> Unit) {
   withContext(currentCoroutineContext() + Dispatchers.IO) {
     val coroutineContext = currentCoroutineContext()
-    this@untilAsserted.ignoreExceptionsMatching { it !is TimeoutCancellationException }
+    this@untilAsserted.ignoreExceptions()
         .logging { LOG.info(it) }
         .pollInSameThread()
         .untilAsserted { runBlocking(coroutineContext) { fn() } }


### PR DESCRIPTION
W/o this, some tests wouldn't retry on a timed out call. It's unclear whether a test needs this to properly fail.

This fixes https://github.com/restatedev/restate/issues/2999.