### PR TITLE
Isolate StopRuntime/KillRuntime

### DIFF
--- a/src/main/kotlin/dev/restate/sdktesting/tests/KillRuntime.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/KillRuntime.kt
@@ -26,9 +26,11 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.parallel.Isolated
 
 @Tag("always-suspending")
 @Tag("only-single-node")
+@Isolated("Starting and stopping the runtime occupies docker resources")
 class KillRuntime {
 
   companion object {

--- a/src/main/kotlin/dev/restate/sdktesting/tests/StopRuntime.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/StopRuntime.kt
@@ -26,9 +26,11 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.parallel.Isolated
 
 @Tag("always-suspending")
 @Tag("only-single-node")
+@Isolated("Starting and stopping the runtime occupies docker resources")
 class StopRuntime {
 
   companion object {


### PR DESCRIPTION
Stopping and restarting the runtime container when other tests are running in parallel can have quite a lag. To reduce the likelihood of timeouts, we try to run these in isolation.