### PR TITLE
Harden various tests

### DIFF
--- a/src/main/kotlin/dev/restate/sdktesting/infra/RestateDeployer.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/infra/RestateDeployer.kt
@@ -132,6 +132,9 @@ private constructor(
               "restate_bifrost" to "trace",
               "restate_core::partitions" to "trace",
               "restate_admin::cluster_controller" to "trace",
+              "restate_core::network" to "trace",
+              "restate_worker::partition_processor_manager" to "trace",
+              "restate_metadata_server" to "trace",
               "restate" to "debug")
       val defaultLog =
           (listOf("info") + defaultLogFilters.map { "${it.key}=${it.value}" }).joinToString(

--- a/src/main/kotlin/dev/restate/sdktesting/tests/Cancellation.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/Cancellation.kt
@@ -122,7 +122,7 @@ class Cancellation {
     // made, so we need to retry.
     await.ignoreException(TimeoutCancellationException::class.java).until {
       runBlocking {
-        testUtilsClient.cancelInvocation(id)
+        testUtilsClient.cancelInvocation(id, idempotentCallOptions)
         withTimeout(1.seconds) { cancelTestClient.verifyTest() }
       }
     }

--- a/src/main/kotlin/dev/restate/sdktesting/tests/Combinators.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/Combinators.kt
@@ -115,14 +115,17 @@ class Combinators {
         {
           assertThat(interpreterClient.hasAwakeable(awk2)).isTrue()
         }
-    assertThat(interpreterClient.hasAwakeable(awk0)).isTrue()
-    assertThat(interpreterClient.hasAwakeable(awk1)).isTrue()
+
+    // hasAwakeable might have to be retried in case of leadership changes
+    assertThat(interpreterClient.hasAwakeable(awk0, idempotentCallOptions)).isTrue()
+    // hasAwakeable might have to be retried in case of leadership changes
+    assertThat(interpreterClient.hasAwakeable(awk1, idempotentCallOptions)).isTrue()
 
     // Now let's reject awakeable 2, this should not complete anything
-    interpreterClient.rejectAwakeable(RejectAwakeable(awk2, "fail"))
+    interpreterClient.rejectAwakeable(RejectAwakeable(awk2, "fail"), idempotentCallOptions)
 
     // Resolve awakeable 1, this will complete successfully
-    interpreterClient.resolveAwakeable(ResolveAwakeable(awk1, "awk1-result"))
+    interpreterClient.resolveAwakeable(ResolveAwakeable(awk1, "awk1-result"), idempotentCallOptions)
 
     assertThat(result.await()).isEqualTo("awk1-result")
   }

--- a/src/main/kotlin/dev/restate/sdktesting/tests/UpgradeWithInFlightInvocation.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/UpgradeWithInFlightInvocation.kt
@@ -83,7 +83,7 @@ class UpgradeWithInFlightInvocation {
             }
 
         // Now register the update
-        registerService2(adminURI)
+        UpgradeWithNewInvocation.registerServiceEndpoint(adminURI, "http://version2:9080/")
 
         // Now let's resume the awakeable
         interpreter.resolveAwakeable(


### PR DESCRIPTION
While trying to debug a runtime problem I needed to run the sdk-tset-suite repeatedly. I stumbled upon a few test instabilities. The main source of instabilities came from not properly handling leadership changes which usually require idempotent invocations to be automatically retried.

Moreover, I increased the log level for a few components to better understand why tests are failing.