### PR TITLE
Minor fixes

### DIFF
--- a/src/main/kotlin/dev/restate/sdktesting/infra/RestateContainer.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/infra/RestateContainer.kt
@@ -85,7 +85,6 @@ class RestateContainer(
                   "RESTATE_METADATA_SERVER__TYPE" to "replicated",
                   "RESTATE_METADATA_CLIENT__ADDRESSES" to
                       "[http://$RESTATE_RUNTIME:$RUNTIME_NODE_PORT]",
-                  "RESTATE_BIFROST__AUTO_RECOVERY_INTERVAL" to "2s",
               )
 
       return listOf(

--- a/src/main/kotlin/dev/restate/sdktesting/tests/Cancellation.kt
+++ b/src/main/kotlin/dev/restate/sdktesting/tests/Cancellation.kt
@@ -123,7 +123,7 @@ class Cancellation {
     await.ignoreException(TimeoutCancellationException::class.java).until {
       runBlocking {
         testUtilsClient.cancelInvocation(id, idempotentCallOptions)
-        withTimeout(1.seconds) { cancelTestClient.verifyTest() }
+        withTimeout(1.seconds) { cancelTestClient.verifyTest(idempotentCallOptions) }
       }
     }
 


### PR DESCRIPTION
[Make Cancellation test idempotent](https://github.com/restatedev/sdk-test-suite/commit/19cb14a2123222a922055cae66bc08cda7a41d0d)

[Revert "Set RESTATE_BIFROST__AUTO_RECOVERY_INTERVAL to 2s"](https://github.com/restatedev/sdk-test-suite/commit/b5e6789d55f2894e0a1c2657563d6e96c90aede2) 

This reverts commit https://github.com/restatedev/sdk-test-suite/commit/9598b015f02582e97906bf8b4904d3f7c6a96abe.